### PR TITLE
Don't dereference nullptr ...

### DIFF
--- a/include/NuECCQE.h
+++ b/include/NuECCQE.h
@@ -870,12 +870,14 @@ void RECOTRACKS_ANA::NuECCQE::Init(TTree *tree)
     fCurrent = -1;
     fChain->SetMakeClass(1);
 
+#if 0
     fChain->GetBranch("prong_axis_vector")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_axis_vertex")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_binned_energy_bin_contents")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_binned_energy_bin_indices")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_part_E")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_part_pos")->SetMakeClass(kFALSE);
+#endif
 
     fChain->SetBranchAddress("eventID", &eventID, &b_eventID);
     fChain->SetBranchAddress("physEvtNum", &physEvtNum, &b_physEvtNum);
@@ -1263,12 +1265,22 @@ Bool_t RECOTRACKS_ANA::NuECCQE::Notify()
     // to the generated code, but the routine can be extended by the
     // user if needed. The return value is currently not used.
 
+#if 0
     fChain->GetBranch("prong_axis_vector")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_axis_vertex")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_binned_energy_bin_contents")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_binned_energy_bin_indices")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_part_E")->SetMakeClass(kFALSE);
     fChain->GetBranch("prong_part_pos")->SetMakeClass(kFALSE);
+#endif
+
+
+    if (b_prong_axis_vector) b_prong_axis_vector->SetMakeClass(kFALSE);
+    if (b_prong_axis_vertex) b_prong_axis_vertex->SetMakeClass(kFALSE);
+    if (b_prong_binned_energy_bin_contents) b_prong_binned_energy_bin_contents->SetMakeClass(kFALSE);
+    if (b_prong_binned_energy_bin_indices) b_prong_binned_energy_bin_indices->SetMakeClass(kFALSE);
+    if (b_prong_part_E) b_prong_part_E->SetMakeClass(kFALSE);
+    if (b_prong_part_pos) b_prong_part_pos->SetMakeClass(kFALSE);
 
     return kTRUE;
 }

--- a/sundry/root2hdf5proj_setup.sh
+++ b/sundry/root2hdf5proj_setup.sh
@@ -2,7 +2,12 @@
 TMP_PRODUCTSROOT="/minerva/app/users/perdue"
 TMP_PRODUCTS="hep_hpc_products"
 TMP_PROJECT="/minerva/app/users/perdue/root2hdf5proj"
-cp ~/.syntastic_cpp_config_root2hdf5 ~/.syntastic_cpp_config
+
+TMP_PRODUCTSROOT=/home/pcanal/scratch/gabe
+TMP_PRODUCT=build
+TMP_PROJECT=/home/pcanal/scratch/gabe/root2hdf5proj
+
+#cp ~/.syntastic_cpp_config_root2hdf5 ~/.syntastic_cpp_config
 pushd $TMP_PRODUCTSROOT >& /dev/null
 source $TMP_PRODUCTS/setup
 setup catch v1_9_6


### PR DESCRIPTION
valgrind runs clean on skimmer_root2hdf5_nueccqe with this changes.

Conclusion: SetMakeClass needs to be in the Notify function but the branch pointer might be null / not yet reacheable when it is called.